### PR TITLE
Properties are now correctly referenced in property maps

### DIFF
--- a/generate_property_map.py
+++ b/generate_property_map.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python2.7
+
+from generator import Generator
+from scraper import Scraper
+import os, json
+
+DOCS_URL = "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/"
+CONTENTS_PAGE = "aws-product-property-reference.html"
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def main():
+    generator = Generator()
+    scraper = Scraper(DOCS_URL)
+    classes = scraper.get_documentation_pages(CONTENTS_PAGE)
+
+    property_types = {}
+    for key, value in classes.items():
+        properties = scraper.get_properties(value)
+        if properties:
+            property_types[key] = properties
+
+    file_path = os.path.join(CURRENT_DIR, "aws_properties_map.json")
+    with open(file_path, "w") as output_file:
+        json.dump(property_types, output_file, sort_keys=True, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scraper.py
+++ b/scraper.py
@@ -14,31 +14,33 @@ class Scraper(object):
         on the page map its text to it's href
         Returns a dictionary in the format { "link text": "docs_page.html", ...}
         """
-        docs_page = urlopen("%s/%s" % (self.docs_url, toc_page))
+        docs_page = urlopen('%s/%s' % (self.docs_url, toc_page))
         soup = BeautifulSoup(docs_page)
-        links = soup.find_all('a')
+        links = soup.find('div', { 'class' : 'highlights' }).findAll('a')
 
         # Parse the list of all classes to get names and URLS
         pages = {}
         for link in links:
             if not link.getText():
                 continue
-            cleanKey = link.getText().replace('\n', '').replace(' ', '')
-            pages[cleanKey] = link['href']
+            title = link.getText().replace('\n', '').replace(' ', '')
+            href = link['href'].replace('.html', '').strip()
+            clean_key = "%s (%s)" % (title, href)
+            pages[clean_key] = link['href']
 
         return pages
 
 
     def get_properties(self, page_url):
-        print("Fetching: %s" % page_url)
-        class_page = urlopen("%s/%s" % (self.docs_url, page_url))
+        print('Fetching: %s' % page_url)
+        class_page = urlopen('%s/%s' % (self.docs_url, page_url))
         if class_page:
             property_types = []
             soup = BeautifulSoup(class_page)
             try:
                 properties_list = soup.dl.contents
             except:
-                print("No docs for page %s" % page_url)
+                print('No docs for page %s' % page_url)
                 return None
 
             # Break the docs up into sections by property
@@ -55,7 +57,6 @@ class Scraper(object):
             # Create a dictionary for each property type
             for s in sections:
                 property_dict = {
-                    'href': None,
                     'list': False,
                     'name': s[0].getText(),
                     'type': 'String'
@@ -71,13 +72,13 @@ class Scraper(object):
                                 .replace('Type:', '')\
                                 .replace('.', '')\
                                 .replace('\n', '').strip()
-                        if 'list of' in clean_text.lower():
+                        if 'list' in clean_text.lower():
                             property_dict['list'] = True
-                            clean_text = clean_text.lower()\
-                                    .replace('a list of', '')\
-                                    .replace('list of', '').strip().title()
+                            lower_text = clean_text.lower()
+                            clean_text = re.sub('a*\s*list\s*(of)*', '', clean_text)\
+                                    .strip().title()
                         if p.a:
-                            property_dict['href'] = p.a.get('href')
+                            clean_text = p.a.get('href').replace('.html','').strip()
                         property_dict['type'] = self._get_type(clean_text)
 
                 property_types.append(property_dict)


### PR DESCRIPTION
There's a bit going on in this commit, so I'll attempt to explain in-line.  The `tl;dr` is that non-primitive types in the property maps are now correctly referenced.  For example:

EC2NetworkInterface has the following property:
```json
    {                                                                  
      "list": true,                                                    
      "name": "PrivateIpAddresses",                                    
      "type": "aws-properties-ec2-network-interface-privateipspec"     
    },   
```

You can now search by the type, and you find the following property type:
```json
  "EC2NetworkInterfacePrivateIPSpecification (aws-properties-ec2-network-interface-privateipspec)": [
    {
      "list": false,
      "name": "PrivateIpAddress",
      "type": "String"
    }
  ],
```

This is a crucial first step to automatically generating types