### PR TITLE
Resource/Property types are now referenced by friendly names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ __pycache__/*
 output/*
 *.swp
 *.pyc
-aws_properties_map.json
+*.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ cd /path/to/scenery-generator/environment/
 git clone ...
 source /path/to/scenery-generator/environment/bin/activate
 pip install beautifulsoup4
+pip install -e git+https://github.com/pwdyson/inflect.py#egg=inflect
 ```
 
 ## Usage
@@ -22,37 +23,33 @@ This library contains two classes:
     contents page of the amazon docs. Returns a dict in the format:
 
 ```python
-{ 'AWS::Resrouce::Type': 'url_to_page.html', ...}
+{ 'AWS::Resrouce::Type': BeautifulSoupObject, ...}
 ```
 
-   - **`get_properties`:** Accepts a URL of a page to a specific Resource
-   (Property) Type, and parses it to find all of the types. Returns a list of
-   dicts representing each property. For example:
+   - **`get_properties`:** Accepts a BeautifulSoup object representing the
+   (Property) Type documentation page, and parses it to find all of the types.
+   Returns a list of dicts representing each property. For example:
 
 ```python
 [{
-  "href": null,
   "list": false,
   "name": "Description",
   "type": "String"
 },
 {
-  "href": null,
   "list": true,
   "name": "GroupSet",
   "type": "String"
 },
 {
-  "href": null,
   "list": false,
   "name": "PrivateIpAddress",
   "type": "String"
 },
 {
-  "href": "aws-properties-ec2-network-interface-privateipspec.html",
   "list": true,
   "name": "PrivateIpAddresses",
-  "type": "Privateipaddressspecification"
+  "type": "PrivateIpAddress"
 },
 ... ]
 ```

--- a/generate_property_map.py
+++ b/generate_property_map.py
@@ -2,24 +2,89 @@
 
 from generator import Generator
 from scraper import Scraper
-import os, json
+import collections, json, os
+import inflect
 
 DOCS_URL = "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/"
-CONTENTS_PAGE = "aws-product-property-reference.html"
+PROPERTY_TYPES_CONTENTS_PAGE = "aws-product-property-reference.html"
+RESOURCE_TYPES_CONTENTS_PAGE = "aws-template-resource-type-ref.html"
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
     generator = Generator()
     scraper = Scraper(DOCS_URL)
-    classes = scraper.get_documentation_pages(CONTENTS_PAGE)
+    property_doc = scraper.get_documentation_pages(PROPERTY_TYPES_CONTENTS_PAGE)
+    resource_doc = scraper.get_documentation_pages(RESOURCE_TYPES_CONTENTS_PAGE)
 
-    property_types = {}
-    for key, value in classes.items():
-        properties = scraper.get_properties(value)
-        if properties:
-            property_types[key] = properties
+    property_type_map = scraper.get_type_map_from_soup(property_doc)
+    resource_type_map = scraper.get_type_map_from_soup(resource_doc)
 
+    clean_property_map = clean_property_type_names(property_type_map, resource_type_map)
+    write_property_map(clean_property_map)
+
+
+
+def clean_property_type_names(property_types, resource_types):
+    """
+    Accepts maps for property_types and resource_types, and creates a lookup
+    table for friendly property type names by href. Then, it attemps to
+    reconstruct the map with friendly names.
+    Returns a propety_types map with friendly names as the key
+    """
+    all_types = dict(property_types.items() + resource_types.items())
+
+    # Create a lookup table of friendly names for all property types,
+    # converting plural nouns to their singular form
+    lookup_table = {}
+    p = inflect.engine()
+    for key, values in all_types.iteritems():
+        for prop in values:
+            if '-' in prop['type']:
+                friendly_name = p.singular_noun(prop['name'])
+                if not friendly_name:
+                    friendly_name = prop['name']
+                lookup_table[prop['type']] = friendly_name
+
+    friendly_names = lookup_table.values()
+    duplicate_names = [x for x, y in collections.Counter(friendly_names).items() if y > 1]
+
+    # For all PROPERTY types (because we only care about beautifying these),
+    # look up the friendly name from the lookup table we constructed
+    clean_property_types = {}
+    for key, value in property_types.iteritems():
+        if not key in lookup_table:
+            print("%s not found in lookup table" % key)
+            clean_property_types[key] = value
+            continue
+        friendly_name = lookup_table[key]
+        if friendly_name in duplicate_names:
+            print("%s is a duplicate" % friendly_name)
+            clean_property_types[key] = value
+        else:
+            clean_property_types[friendly_name] = value
+
+    # Finally, we need to scan every single value and change the href types
+    # to the (singular) friendly names in the lookup table
+    immaculate_property_types = {}
+    for key, values in clean_property_types.iteritems():
+        new_values = []
+        for prop in values:
+            if prop['type'] in lookup_table:
+                new_type = lookup_table[prop['type']]
+                if new_type not in duplicate_names:
+                    print("Changing type from %s to %s" % (prop['type'], new_type))
+                    prop['type'] = new_type
+            new_values.append(prop)
+        immaculate_property_types[key] = new_values
+
+    return clean_property_types
+
+
+def write_property_map(property_types):
+    """
+    Accepts a property_types map and outputs it as JSON
+    """
     file_path = os.path.join(CURRENT_DIR, "aws_properties_map.json")
     with open(file_path, "w") as output_file:
         json.dump(property_types, output_file, sort_keys=True, indent=2)

--- a/generate_resource_map.py
+++ b/generate_resource_map.py
@@ -5,24 +5,47 @@ from scraper import Scraper
 import os, json
 
 DOCS_URL = "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/"
-CONTENTS_PAGE = "aws-template-resource-type-ref.html"
+PROPERTY_TYPES_CONTENTS_PAGE = "aws-product-property-reference.html"
+RESOURCE_TYPES_CONTENTS_PAGE = "aws-template-resource-type-ref.html"
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
-    generator = Generator()
     scraper = Scraper(DOCS_URL)
-    classes = scraper.get_documentation_pages(CONTENTS_PAGE)
+    property_doc = scraper.get_documentation_pages(PROPERTY_TYPES_CONTENTS_PAGE)
+    resource_doc = scraper.get_documentation_pages(RESOURCE_TYPES_CONTENTS_PAGE)
 
-    property_types = {}
-    for key, value in classes.items():
-        properties = scraper.get_properties(value)
-        if properties:
-            property_types[key] = properties
+    property_type_map = scraper.get_type_map_from_soup(property_doc)
+    resource_type_map = scraper.get_type_map_from_soup(resource_doc)
 
-    file_path = os.path.join(CURRENT_DIR, "aws_resources_map.json")
-    with open(file_path, "w") as output_file:
-        json.dump(property_types, output_file, sort_keys=True, indent=2)
+    clean_resource_map = clean_resource_property_names(
+            property_type_map, resource_type_map)
+
+    generator = Generator()
+    generator.write_property_map('aws_resources_map.json', clean_resource_map)
+
+
+def clean_resource_property_names(property_types, resource_types):
+    generator = Generator()
+    lookup_table, duplicate_names = generator.build_friendly_lookup_table(
+            property_types, resource_types)
+
+    # Change the href types to the friendly names in the lookup table
+    clean_resource_types = {}
+    for key, values in resource_types.iteritems():
+        new_values = []
+        for prop in values:
+            if prop['type'] in lookup_table:
+                new_type = lookup_table[prop['type']]
+                if new_type not in duplicate_names:
+                    print("Changing type from %s to %s" % (prop['type'], new_type))
+                    prop['type'] = new_type
+            new_values.append(prop)
+        clean_resource_types[key] = new_values
+
+    return clean_resource_types
+
+
 
 
 if __name__ == '__main__':

--- a/scraper.py
+++ b/scraper.py
@@ -62,11 +62,14 @@ class Scraper(object):
 
 
     def get_type_title_and_reference(self, link):
+        title = link.getText().replace('\n', '').replace(' ', '')
         href = link['href'].replace('.html', '').strip()
+
+        # For Resource Types, we need the pretty name
+        if ':' in title:
+            return title
+
         return href
-        #title = link.getText().replace('\n', '').replace(' ', '')
-        #clean_key = "%s (%s)" % (title, href)
-        #return clean_key
 
 
     def get_properties(self, soup):


### PR DESCRIPTION
This is the case for all non-duplicate friendly names.  For example, we have a couple `Ebs` types, so they're referenced by their longer names:
```
aws-properties-ec2-blockdev-template
aws-properties-as-launchconfig-blockdev-template
```

The result are resource type maps that look like this:
```json
  "AWS::DynamoDB::Table": [                                                                                                    
    {
      "list": true,                                                                                                            
      "name": "AttributeDefinitions",                                                                                          
      "type": "AttributeDefinition"
    }, 
    {
      "list": false,                                                                                                           
      "name": "GlobalSecondaryIndexes",                                                                                        
      "type": "GlobalSecondaryIndex"                                                                                           
    }, 
    {                                                                                                                          
      "list": false,                                                                                                           
      "name": "KeySchema", 
      "type": "KeySchema"                                                                                                      
    }, 
    { 
      "list": false, 
      "name": "LocalSecondaryIndexes",                                                                                         
      "type": "LocalSecondaryIndex"                                                                                            
    }, 
    { 
      "list": false, 
      "name": "ProvisionedThroughput",                                                                                         
      "type": "ProvisionedThroughput"                                                                                          
    }, 
    { 
      "list": false, 
      "name": "TableName",                                                                                                     
      "type": "TableName"                                                                                                      
    } 
  ],  
```

Where the types can be found in the property map:
```json
  "KeySchema": [
    {
      "list": false,
      "name": "AttributeName",
      "type": "String"
    },
    {
      "list": false,
      "name": "KeyType",
      "type": "String"
    }
  ],
etc...
```