### PR TITLE
First pass at generating Property classes!

### DIFF
--- a/generate_property_classes.py
+++ b/generate_property_classes.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python2.7
+
+from generator import Generator
+from scraper import Scraper
+import os, pprint
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def main():
+    generator = Generator()
+    template_file = os.path.join(CURRENT_DIR,
+            'templates', 'property_type_template.js')
+
+    property_type_map = os.path.join(CURRENT_DIR, 'aws_properties_map.json')
+    property_type_dict = generator.read_property_map(property_type_map)
+
+    # For each AWS Type, retrieve the list of properties and generate class file
+    for key, value in property_type_dict.iteritems():
+        try:
+            property_map = { p['name']: p['type'] for p in value }
+            generator.create_property_class_file(template_file, key, property_map)
+        except Exception as exc:
+            print("Failed to generate file for %s: %s" % (key, exc))
+
+if __name__ == '__main__':
+    main()

--- a/generate_property_map.py
+++ b/generate_property_map.py
@@ -48,14 +48,15 @@ def clean_property_type_names(property_types, resource_types):
     # look up the friendly name from the lookup table we constructed
     clean_property_types = {}
     for key, value in property_types.iteritems():
-        if not key in lookup_table:
-            print("%s not found in lookup table" % key)
-            clean_property_types[key] = value
+        newKey = key.replace('-', '_')
+        if not newKey in lookup_table:
+            print("%s not found in lookup table" % newKey)
+            clean_property_types[newKey] = value
             continue
-        friendly_name = lookup_table[key]
+        friendly_name = lookup_table[newKey]
         if friendly_name in duplicate_names:
             print("%s is a duplicate" % friendly_name)
-            clean_property_types[key] = value
+            clean_property_types[newKey] = value
         else:
             clean_property_types[friendly_name] = value
 

--- a/generate_resource_classes.py
+++ b/generate_resource_classes.py
@@ -4,8 +4,6 @@ from generator import Generator
 from scraper import Scraper
 import os, pprint
 
-DOCS_URL = "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/"
-CONTENTS_PAGE = "aws-template-resource-type-ref.html"
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/generate_resource_types.py
+++ b/generate_resource_types.py
@@ -11,21 +11,19 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def main():
     generator = Generator()
-    scraper = Scraper(DOCS_URL)
-    classes = scraper.get_documentation_pages(CONTENTS_PAGE)
     template_file = os.path.join(CURRENT_DIR,
             'templates', 'resource_type_template.js')
 
-    # For each AWS Type, retrieve the list of properties and generate class file
-    for key, value in classes.items():
-        properties = scraper.get_properties(value)
-        if properties:
-            try:
-                property_map = { p['name']: p['type'] for p in properties }
-                generator.create_class_file(template_file, key, property_map)
-            except:
-                print("Failed to generate file for %s: %s" % (key, properties))
+    resource_type_map = os.path.join(CURRENT_DIR, 'aws_resources_map.json')
+    resource_type_dict = generator.read_property_map(resource_type_map)
 
+    # For each AWS Type, retrieve the list of properties and generate class file
+    for key, value in resource_type_dict.iteritems():
+        try:
+            property_map = { p['name']: p['type'] for p in value }
+            generator.create_resource_class_file(template_file, key, property_map)
+        except Exception as exc:
+            print("Failed to generate file for %s: %s" % (key, exc))
 
 if __name__ == '__main__':
     main()

--- a/generator.py
+++ b/generator.py
@@ -44,8 +44,25 @@ class Generator(object):
             json.dump(property_types, output_file, sort_keys=True, indent=2)
 
 
-    def create_class_file(self, template, class_name, property_map):
-        """ Generates a scenery class file.
+    def read_property_map(self, filename):
+        """
+        Accepts a file path to a JSON file
+        Parses the file and returns the resulting dict
+        """
+        file_path = os.path.join(CURRENT_DIR, filename)
+        with open(file_path, "r") as output_file:
+            data = json.load(output_file, object_hook=self.encode_dict_in_ascii)
+            return data
+
+
+    def encode_dict_in_ascii(self, data):
+        ascii_encode = lambda x: x.encode('ascii') \
+                if isinstance(x, unicode) else x
+        return dict(map(ascii_encode, pair) for pair in data.items())
+
+
+    def create_resource_class_file(self, template, class_name, property_map):
+        """ Generates a scenery resource class file.
         template: file path to the scenery class template file
         class_name: AWS class name in the format AWS::DynamoDB::Table
         property_map: Dict represneting property types of the above class """

--- a/generator.py
+++ b/generator.py
@@ -24,7 +24,7 @@ class Generator(object):
         p = inflect.engine()
         for key, values in all_types.iteritems():
             for prop in values:
-                if '-' in prop['type']:
+                if '_' in prop['type']:
                     friendly_name = p.singular_noun(prop['name'])
                     if not friendly_name:
                         friendly_name = prop['name']

--- a/scraper.py
+++ b/scraper.py
@@ -141,7 +141,10 @@ class Scraper(object):
                     clean_text = re.sub('a*\s*list\s*(of)*', '', clean_text)\
                             .strip().title()
                 if p.a:
-                    clean_text = p.a.get('href').replace('.html','').strip()
+                    clean_text = p.a.get('href')\
+                            .replace('.html','')\
+                            .replace('-', '_')\
+                            .strip()
                 property_dict['type'] = self._get_type(clean_text)
 
             property_types.append(property_dict)

--- a/templates/property_type_template.js
+++ b/templates/property_type_template.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+// TODO: Create a Property base class so properties don't extend Resource!
 var Resource = require('../Resource.js');
 %s
 
@@ -21,6 +22,7 @@ var propertyMap = %s;
 var Class = function (id) {
     return Resource.call(this, id, '%s', {});
 };
+// TODO: Create a Property base class so properties don't extend Resource!
 require('util').inherits(Class, Resource);
 
 // TODO: Update registerPropertyPrototypes to accommodate property types

--- a/templates/resource_type_template.js
+++ b/templates/resource_type_template.js
@@ -15,6 +15,8 @@
 'use strict';
 
 var Resource = require('../Resource.js');
+%s
+
 var propertyMap = %s;
 var Class = function (id) {
     return Resource.call(this, id, '%s', {});


### PR DESCRIPTION
Right now, they extend Resource. We'll want to change them to extend the base Property class once we write it on the javascript side of things, but for now, we are generating property classes!  I've added some helpful `TODOs` in the generated code to remind us.  Here's what we're looking at:

# CacheBeahvior.js
```javascript
// Copyright 2015 OpenWhere, Inc.
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

'use strict';

// TODO: Create a Property base class so properties don't extend Resource!
var Resource = require('../Resource.js');
var ForwardedValue = require('../properties/ForwardedValue.js');

var propertyMap = {
    'AllowedMethods': 'String',
    'ForwardedValues': ForwardedValue,
    'MinTTL': 'String',
    'PathPattern': 'String',
    'SmoothStreaming': 'Boolean',
    'TargetOriginId': 'String',
    'TrustedSigners': 'String',
    'ViewerProtocolPolicy': 'String'
};
var Class = function (id) {
    return Resource.call(this, id, 'CacheBehavior', {});
};
// TODO: Create a Property base class so properties don't extend Resource!
require('util').inherits(Class, Resource);

// TODO: Update registerPropertyPrototypes to accommodate property types
Class = Resource.registerPropertyPrototypes(Class, propertyMap);
module.exports = Class;
```

To generate these, you'll need to run the following files:

First,
+ `generate_property_map.js`
+ `generate_resource_map.js`

Then,
+ `generate_property_classes.js`