### PR TITLE
Property Maps now contain more information in generated classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Scenery Generator
 Generates Scenery class files from the [Cloudformation Documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
 
+## License
+This Software is licensed under the Apache 2.0 license. See the LICENSE file for
+details.
+
 ## Setup
 On OSX:
 ```bash
@@ -14,53 +18,44 @@ pip install beautifulsoup4
 pip install -e git+https://github.com/pwdyson/inflect.py#egg=inflect
 ```
 
+## Type Classification
+There are two type classifications available in the [AWS Cloudformation Documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html):
+
+1. Resource Types
+2. Property Types
+
+**Resource Types** are classes that correspond to an AWS Resource.
+
+**Property Types** are classes that are used to help define and create Resource
+Types.
+
+Resource types will contain key-value pairs of properties. Some of these
+properties are primitives (including `String`, `Number`, `Boolean`, and `Object`).
+If a resource's property is not of a primitive Javascript type, it will be a
+Property Type object.
+
+Property types can sometimes contain other property types in their definitions.
+
 ## Usage
-This library contains two classes:
-+ **Scraper:** Responsible for fetching data and parsing HTML from the AWS
-  documentation. It has three functions:
-    - **Constructor:** Accepts a URL of the AWS CloudFormation Documentation
-    - **`get_documentation_pages`:** Accepts a string representing the table of
-    contents page of the amazon docs. Returns a dict in the format:
+Scenery Generator offers two types of output:
 
-```python
-{ 'AWS::Resrouce::Type': BeautifulSoupObject, ...}
+1. Property Maps
+2. Scenery Classes
+
+Property Maps are JSON files containing a definition of every AWS CloudFormation
+object as scraped from the documentation.
+
+Scenery Classes are Javascript files that are generated based on the Property
+Maps.
+
+There are four commands you can run. If running all four commands, run them
+in the following order:
+
+```
+./generate_property_map.py
+./generate_resource_map.py
+./generate_property_classes.py
+./generate_resource_classes.py
 ```
 
-   - **`get_properties`:** Accepts a BeautifulSoup object representing the
-   (Property) Type documentation page, and parses it to find all of the types.
-   Returns a list of dicts representing each property. For example:
-
-```python
-[{
-  "list": false,
-  "name": "Description",
-  "type": "String"
-},
-{
-  "list": true,
-  "name": "GroupSet",
-  "type": "String"
-},
-{
-  "list": false,
-  "name": "PrivateIpAddress",
-  "type": "String"
-},
-{
-  "list": true,
-  "name": "PrivateIpAddresses",
-  "type": "PrivateIpAddress"
-},
-... ]
-```
-
-See `generate_property_map.py` for an example of how to use this class.
-
-+ **Generator:** Responsible for generating [Scenery](https://github.com/OpenWhere/scenery)
-  class files through the magic of string interpolation and the use of the Scraper
-  class to fetch data from the web. The code is pretty self-explanatory -- see
-  `generate_resource_types` for an example of how to use this class.
-
-## License
-This Software is licensed under the Apache 2.0 license. See the LICENSE file for
-details.
+The Scenery classes are output into the the `output` folder.

--- a/generate_property_classes.py
+++ b/generate_property_classes.py
@@ -18,7 +18,7 @@ def main():
     # For each AWS Type, retrieve the list of properties and generate class file
     for key, value in property_type_dict.iteritems():
         try:
-            property_map = { p['name']: p['type'] for p in value }
+            property_map = { p['name']: {'type': p['type'], 'list': p['list']}  for p in value }
             generator.create_property_class_file(template_file, key, property_map)
         except Exception as exc:
             print("Failed to generate file for %s: %s" % (key, exc))

--- a/generate_resource_classes.py
+++ b/generate_resource_classes.py
@@ -18,7 +18,7 @@ def main():
     # For each AWS Type, retrieve the list of properties and generate class file
     for key, value in resource_type_dict.iteritems():
         try:
-            property_map = { p['name']: p['type'] for p in value }
+            property_map = { p['name']: {'type': p['type'], 'list': p['list']}  for p in value }
             generator.create_resource_class_file(template_file, key, property_map)
         except Exception as exc:
             print("Failed to generate file for %s: %s" % (key, exc))

--- a/generator.py
+++ b/generator.py
@@ -96,8 +96,7 @@ class Generator(object):
 
         # Generate the formatted property map
         formatted_pm = pprint.pformat(property_map, indent=4, width=100)\
-                .replace( '{', '{\n ')\
-                .replace( '}', '\n}')
+                .replace("   '", "'")
 
         # All non-primitives need to have quotes removed from around them
         for np in non_primitives:
@@ -119,7 +118,7 @@ class Generator(object):
         non_primitives = []
         require_statements = []
         for value in property_map.values():
-            clean_value = value.replace('"', '').strip()
+            clean_value = value['type'].replace('"', '').strip()
             if clean_value not in primitives:
                 non_primitives.append(clean_value)
                 require_statement = statement.format(clean_value)

--- a/generator.py
+++ b/generator.py
@@ -96,7 +96,9 @@ class Generator(object):
 
         # Generate the formatted property map
         formatted_pm = pprint.pformat(property_map, indent=4, width=100)\
-                .replace("   '", "'")
+                .replace("   '", "'")\
+                .replace('True', 'true')\
+                .replace('False', 'false')
 
         # All non-primitives need to have quotes removed from around them
         for np in non_primitives:

--- a/scraper.py
+++ b/scraper.py
@@ -131,21 +131,27 @@ class Scraper(object):
                 if not "Type" in text_contents:
                     continue
                 clean_text = re.sub(' +', '', text_contents)\
-                        .replace('Type', '')\
-                        .replace('.', '')\
-                        .replace(':', '')\
-                        .replace('\n', '').strip()
+                            .replace('Type', '')\
+                            .replace('.', '')\
+                            .replace(':', '')\
+                            .replace('\n', '').strip()
                 if 'list' in clean_text.lower():
                     property_dict['list'] = True
                     lower_text = clean_text.lower()
                     clean_text = re.sub('a*\s*list\s*(of)*', '', clean_text)\
-                            .strip().title()
+                                .strip().title()
                 if p.a:
                     clean_text = p.a.get('href')\
-                            .replace('.html','')\
-                            .replace('-', '_')\
-                            .strip()
+                                .replace('.html','')\
+                                .replace('-', '_')\
+                                .strip()
                 property_dict['type'] = self._get_type(clean_text)
+
+                # Field-specific types
+                if name == 'Attributes':
+                    property_dict['list'] = False
+                    property_dict['type'] = 'Object'
+
 
             property_types.append(property_dict)
         return property_types
@@ -159,4 +165,6 @@ class Scraper(object):
             return 'Number'
         if 'boolean' in string:
             return 'Boolean'
+        if 'json' in string:
+            return 'Object'
         return type_string

--- a/scraper.py
+++ b/scraper.py
@@ -152,10 +152,37 @@ class Scraper(object):
                     property_dict['list'] = False
                     property_dict['type'] = 'Object'
 
+                clean_type = self._get_type(clean_text)
+                if self._is_exceptional_type(clean_type):
+                    property_dict['type'] = 'String'
+                else:
+                    property_dict['type'] = clean_type
 
             property_types.append(property_dict)
         return property_types
 
+
+    def _clean_name(self, name_string):
+        """ Removes spaces and parenthetical statements from names """
+        clean_name = re.sub('\(.*', '', name_string)
+        clean_name = re.sub('\s', '', clean_name)
+        return clean_name
+
+
+    def _is_exceptional_type(self, type_string):
+        """
+        This function checks whether or not type_string is a problem child and,
+        if so, converts the type to "String." There were a couple types in the
+        documentation that are not properly defined (and therefore can't be
+        parsed), but String appears to be the valid type for all of them.
+        """
+        if 'Youcannotcreate' in type_string:
+            return True
+        if 'curitygroup' in type_string:
+            return True
+        if 'referencestoawsiamroles' in type_string:
+            return True
+        return False
 
     def _get_type(self, type_string):
         string = type_string.lower()

--- a/templates/property_type_template.js
+++ b/templates/property_type_template.js
@@ -19,6 +19,7 @@ var Resource = require('../Resource.js');
 %s
 
 var propertyMap = %s;
+
 var Class = function (id) {
     return Resource.call(this, id, '%s', {});
 };

--- a/templates/resource_type_template.js
+++ b/templates/resource_type_template.js
@@ -18,6 +18,7 @@ var Resource = require('../Resource.js');
 %s
 
 var propertyMap = %s;
+
 var Class = function (id) {
     return Resource.call(this, id, '%s', {});
 };


### PR DESCRIPTION
In order to provide some indication of whether or not a property should be a list of properties, the `propertyMap` in the generated classes has had its value changed to an object containing both type and whether or not the property is a list.

```javascript
var propertyMap = {'AttributeDefinitions': {'list': true, 'type': AttributeDefinition},
 'GlobalSecondaryIndexes': {'list': false, 'type': GlobalSecondaryIndex},
 'KeySchema': {'list': false, 'type': KeySchema},
 'LocalSecondaryIndexes': {'list': false, 'type': LocalSecondaryIndex},
 'ProvisionedThroughput': {'list': false, 'type': ProvisionedThroughput},
 'TableName': {'list': false, 'type': TableName}};
```

Additionally, the README has been updated so that it's readable and functional.

This pull request addresses #15, but generated code is not yet compatible in Scenery