### PR TITLE
Fix bug where AWS fully-qualified-names were being crushed

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -5,7 +5,10 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class Generator(object):
     def __init__(self):
-        pass
+        self.property_types = self.read_property_map(
+                os.path.join(CURRENT_DIR, 'aws_properties_map.json'))
+        self.resource_types = self.read_property_map(
+                os.path.join(CURRENT_DIR, 'aws_resources_map.json'))
 
 
     def build_friendly_lookup_table(self, property_types, resource_types):
@@ -122,9 +125,13 @@ class Generator(object):
         for value in property_map.values():
             clean_value = value['type'].replace('"', '').strip()
             if clean_value not in primitives:
-                non_primitives.append(clean_value)
-                require_statement = statement.format(clean_value)
-                require_statements.append(require_statement)
+                if clean_value not in self.property_types.keys():
+                    print("%s does not exist in the properties directory" % clean_value)
+                    # TODO: Look it up from the resources instead
+                else:
+                    non_primitives.append(clean_value)
+                    require_statement = statement.format(clean_value)
+                    require_statements.append(require_statement)
 
         if non_primitives:
             require_statements = "\n".join(require_statements)

--- a/generator.py
+++ b/generator.py
@@ -120,14 +120,33 @@ class Generator(object):
     def get_require_statements(self, property_map):
         primitives = ['string', 'number', 'boolean', 'object']
         statement = "var {0} = require('../properties/{0}.js');"
+        resource_statement = "var {0} = require('../{1}/{0}.js');"
         non_primitives = []
         require_statements = []
         for value in property_map.values():
             clean_value = value['type'].replace('"', '').strip()
             if clean_value not in primitives:
                 if clean_value not in self.property_types.keys():
-                    print("%s does not exist in the properties directory" % clean_value)
-                    # TODO: Look it up from the resources instead
+                    resource_refs = [ k for k in self.resource_types.keys() \
+                                      if clean_value in k ]
+
+                    if not resource_refs:
+                        print("%s does not exist in properties or resources" % clean_value)
+                        """ TODO: The following documentation edge cases are causing errors:
+
+                        Listofroutetableids does not exist in properties or resources
+                        Listofusers does not exist in properties or resources
+                        LoginProfiletype does not exist in properties or resources
+                        ExampleNetbiosNode2 does not exist in properties or resources
+                        """
+                        continue
+
+                    # TODO: Handle multiple references? No issues with this yet!
+                    aws, directory, resource = resource_refs[0].split("::")
+                    print("Found %s in the resources dict: %s" % (resource, directory))
+                    non_primitives.append(resource)
+                    require_statement = resource_statement.format(resource, directory)
+                    require_statements.append(require_statement)
                 else:
                     non_primitives.append(clean_value)
                     require_statement = statement.format(clean_value)

--- a/generator.py
+++ b/generator.py
@@ -73,9 +73,9 @@ class Generator(object):
         if len(class_array) < 3:
             return None
 
-        class_name = class_array[2]
+        simple_class_name = class_array[2]
         output_dir = os.path.join(CURRENT_DIR, 'output', class_array[1])
-        file_path = os.path.join(output_dir, class_name + ".js")
+        file_path = os.path.join(output_dir, simple_class_name + ".js")
         return self.create_and_write_template(
                 class_name, property_map, template, output_dir, file_path)
 

--- a/scraper.py
+++ b/scraper.py
@@ -188,11 +188,16 @@ class Scraper(object):
 
 
     def _is_object_type(self, type_string):
+        """
+        Handle edge-case types that should be objects
+        """
         exceptional_strings = [
             'Attribute',
             'aws_properties_name',
             'RefID',
             'Aamazonsnstopicsarns',
+            'LoginProfiletype',
+            'ExampleNetbiosNode2',
         ]
         for es in exceptional_strings:
             if es in type_string:
@@ -203,10 +208,7 @@ class Scraper(object):
 
     def _is_string_type(self, type_string):
         """
-        This function checks whether or not type_string is a problem child and,
-        if so, converts the type to "string." There were a couple types in the
-        documentation that are not properly defined (and therefore can't be
-        parsed), but string appears to be the valid type for all of them.
+        Handle edge-case types that should be strings
         """
         exceptional_strings = [
             'Youcannotcreate',
@@ -214,6 +216,8 @@ class Scraper(object):
             'curitygroup',
             'referencestoawsiamroles',
             'Timestamp',
+            'Listofroutetableids',
+            'Listofusers',
         ]
         for es in exceptional_strings:
             if es in type_string:

--- a/scraper.py
+++ b/scraper.py
@@ -78,10 +78,26 @@ class Scraper(object):
         of all property/resource types in the docs_page_dict
         """
         type_map = {}
-        for key, value in docs_page_dict.items():
+        for key, value in docs_page_dict.iteritems():
             properties = self.get_properties(value)
             if properties:
                 type_map[key] = properties
+            else:
+                # TODO: Fix these hard-coded edge cases and find an elegant solution
+                if key == 'aws-properties-stack-parameters':
+                    type_map[key] = [{'name': 'properties', 'type': 'object', 'list': False}]
+                elif key == 'aws-properties-ec2-port-range':
+                    type_map[key] = [
+                            { 'name': 'from', 'type': 'number', 'list': False },
+                            { 'name': 'to', 'type': 'number', 'list': False },
+                    ]
+                elif key == 'aws-properties-ec2-icmp':
+                    type_map[key] = [
+                            { 'name': 'code', 'type': 'number', 'list': False },
+                            { 'name': 'type', 'type': 'number', 'list': False },
+                    ]
+                else:
+                    print("No properties found for %s" % key)
 
         return type_map
 
@@ -147,16 +163,18 @@ class Scraper(object):
                                 .strip()
                 property_dict['type'] = self._get_type(clean_text)
 
-                # Field-specific types
-                if name == 'Attributes':
-                    property_dict['list'] = False
-                    property_dict['type'] = 'object'
-
                 clean_type = self._get_type(clean_text)
-                if self._is_exceptional_type(clean_type):
+                if self._is_string_type(clean_type):
                     property_dict['type'] = 'string'
+                elif self._is_object_type(clean_type):
+                    property_dict['type'] = 'object'
                 else:
                     property_dict['type'] = clean_type
+
+                # Field-specific types
+                if 'Attributes' in name:
+                    property_dict['list'] = False
+                    property_dict['type'] = 'object'
 
             property_types.append(property_dict)
         return property_types
@@ -169,7 +187,21 @@ class Scraper(object):
         return clean_name
 
 
-    def _is_exceptional_type(self, type_string):
+    def _is_object_type(self, type_string):
+        exceptional_strings = [
+            'Attribute',
+            'aws_properties_name',
+            'RefID',
+            'Aamazonsnstopicsarns',
+        ]
+        for es in exceptional_strings:
+            if es in type_string:
+                return True
+
+        return False
+
+
+    def _is_string_type(self, type_string):
         """
         This function checks whether or not type_string is a problem child and,
         if so, converts the type to "string." There were a couple types in the
@@ -181,11 +213,7 @@ class Scraper(object):
             'anemptymap',
             'curitygroup',
             'referencestoawsiamroles',
-
-            # These may need to be objects
-            'aws_properties_name',
-            'RefID',
-            'Aamazonsnstopicsarns',
+            'Timestamp',
         ]
         for es in exceptional_strings:
             if es in type_string:

--- a/scraper.py
+++ b/scraper.py
@@ -181,6 +181,11 @@ class Scraper(object):
             'anemptymap',
             'curitygroup',
             'referencestoawsiamroles',
+
+            # These may need to be objects
+            'aws_properties_name',
+            'RefID',
+            'Aamazonsnstopicsarns',
         ]
         for es in exceptional_strings:
             if es in type_string:


### PR DESCRIPTION
Resources files are now correctly typed by their FQN: `AWS::EC2::Instance` instead of simply `Instance`.

These files are still output with simple names though: `lib/EC2/Instance.js`.

Please merge #19 to see the true diff