### PR TITLE
Property Name Adjustments

### DIFF
--- a/generate_property_map.py
+++ b/generate_property_map.py
@@ -48,7 +48,11 @@ def clean_property_type_names(property_types, resource_types):
     # look up the friendly name from the lookup table we constructed
     clean_property_types = {}
     for key, value in property_types.iteritems():
-        newKey = key.replace('-', '_')
+        newKey = key.replace('-', '_')\
+                    .replace('aws_properties_', '')\
+                    .replace('aws_property_', '')\
+                    .replace('as_', '')\
+                    .strip()
         if not newKey in lookup_table:
             print("%s not found in lookup table" % newKey)
             clean_property_types[newKey] = value

--- a/generate_property_map.py
+++ b/generate_property_map.py
@@ -16,8 +16,8 @@ def main():
     resource_cache_dir = None
 
     # Uncomment the following lines if you have cached docs you wish to use
-    property_cache_dir = os.path.join(CURRENT_DIR, 'cache/properties')
-    resource_cache_dir = os.path.join(CURRENT_DIR, 'cache/resources')
+    #property_cache_dir = os.path.join(CURRENT_DIR, 'cache/properties')
+    #resource_cache_dir = os.path.join(CURRENT_DIR, 'cache/resources')
 
     property_doc = scraper.get_documentation_pages(PROPERTY_TYPES_CONTENTS_PAGE, property_cache_dir)
     resource_doc = scraper.get_documentation_pages(RESOURCE_TYPES_CONTENTS_PAGE, resource_cache_dir)

--- a/generate_resource_map.py
+++ b/generate_resource_map.py
@@ -16,8 +16,8 @@ def main():
     resource_cache_dir = None
 
     # Uncomment the following lines if you have cached docs you wish to use
-    property_cache_dir = os.path.join(CURRENT_DIR, 'cache/properties')
-    resource_cache_dir = os.path.join(CURRENT_DIR, 'cache/resources')
+    #property_cache_dir = os.path.join(CURRENT_DIR, 'cache/properties')
+    #resource_cache_dir = os.path.join(CURRENT_DIR, 'cache/resources')
 
     property_doc = scraper.get_documentation_pages(PROPERTY_TYPES_CONTENTS_PAGE, property_cache_dir)
     resource_doc = scraper.get_documentation_pages(RESOURCE_TYPES_CONTENTS_PAGE, resource_cache_dir)

--- a/generator.py
+++ b/generator.py
@@ -24,10 +24,13 @@ class Generator(object):
         p = inflect.engine()
         for key, values in all_types.iteritems():
             for prop in values:
-                if '_' in prop['type'] or '-' in prop['type']:
-                    friendly_name = p.singular_noun(prop['name'])
+                if '-' in prop['type']:
+                    prop['type'] = prop['type'].replace('-', '_')
+                if '_' in prop['type']:
+                    camelCaseType = self.to_camel_case(prop['type'])
+                    friendly_name = p.singular_noun(camelCaseType)
                     if not friendly_name:
-                        friendly_name = prop['name']
+                        friendly_name = camelCaseType
                     lookup_table[prop['type']] = friendly_name
 
         friendly_names = lookup_table.values()
@@ -131,3 +134,8 @@ class Generator(object):
             return require_statements, non_primitives
         else:
             return '', non_primitives
+
+    def to_camel_case(self, snake_str):
+        components = snake_str.split('_')
+        # Capitalize the first letter of each component and join them together.
+        return "".join([x.title() for x in components])

--- a/scraper.py
+++ b/scraper.py
@@ -149,16 +149,16 @@ class Scraper(object):
                                 .replace('as_', '')\
                                 .strip()
 
-                # Field-specific types
-                if name == 'Attributes':
-                    property_dict['list'] = False
-                    property_dict['type'] = 'object'
-
                 clean_type = self._get_type(clean_text)
                 if self._is_exceptional_type(clean_type):
                     property_dict['type'] = 'string'
                 else:
                     property_dict['type'] = clean_type
+
+                # Field-specific types
+                if name == 'Attributes':
+                    property_dict['list'] = False
+                    property_dict['type'] = 'object'
 
             property_types.append(property_dict)
         return property_types

--- a/scraper.py
+++ b/scraper.py
@@ -238,4 +238,6 @@ class Scraper(object):
             return 'boolean'
         if 'json' in string:
             return 'object'
+        if 'name' in string:
+            return 'string'
         return type_string

--- a/scraper.py
+++ b/scraper.py
@@ -144,8 +144,10 @@ class Scraper(object):
                     clean_text = p.a.get('href')\
                                 .replace('.html','')\
                                 .replace('-', '_')\
+                                .replace('aws_properties_', '')\
+                                .replace('aws_property_', '')\
+                                .replace('as_', '')\
                                 .strip()
-                property_dict['type'] = self._get_type(clean_text)
 
                 # Field-specific types
                 if name == 'Attributes':


### PR DESCRIPTION
(Please merge the other pull requests first before you look at this diff)

This pull request addresses #23, **but maybe we shouldn't merge this.**  Tell me which you like better; we can always implement a one-off fix for SecurityGroup property files.

This refactor names Property Types after the value on the right side of the colon in the documentation, instead of on the left.

# Pros:
* Confusion has been resolved with some classes. For example:
```
- 'SecurityGroupEgress': {'list': false, 'type': SecurityGroupIngres},
+ 'SecurityGroupEgress': {'list': false, 'type': Ec2SecurityGroupRule},
```

* Longer names have been shortened to something more readable. For example:
```
-var aws_properties_stack_parameters = require('../properties/aws_properties_stack_parameters.js');
+var StackParameter = require('../properties/StackParameter.js');
```

# Cons:
Some names have become more confusing and no longer correspond in name to the field to which they're being assigned. For example:

```
- 'GlobalSecondaryIndexes': {'list': false, 'type': GlobalSecondaryIndex},
- 'KeySchema': {'list': false, 'type': KeySchema},
- 'LocalSecondaryIndexes': {'list': false, 'type': LocalSecondaryIndex},
- 'ProvisionedThroughput': {'list': false, 'type': ProvisionedThroughput},

+ 'GlobalSecondaryIndexes': {'list': false, 'type': DynamodbGsi},
+ 'KeySchema': {'list': false, 'type': DynamodbKeyschema},
+ 'LocalSecondaryIndexes': {'list': false, 'type': DynamodbLsi},
+ 'ProvisionedThroughput': {'list': false, 'type': DynamodbProvisionedthroughput},
```

Basically, it's no longer safe to assume that the property you want to assign has the same name as the field to which you're assigning it, but with the added benefit of property types matching a little more closely the AWS documentation.  They're all imported at the top of the file, anyway.  I could go either way on this one.